### PR TITLE
Notification check height changes

### DIFF
--- a/src/main/java/xyz/jpenilla/wanderingtrades/config/Config.java
+++ b/src/main/java/xyz/jpenilla/wanderingtrades/config/Config.java
@@ -59,6 +59,7 @@ public final class Config extends DefaultedConfig {
         this.updateChecker = config.getBoolean(Fields.updateChecker);
 
         final int oldTraderSpawnNotificationRadius = config.getInt(Fields.traderSpawnNotificationRadius);
+        final boolean sphereTraderNotificationRadius = config.getBoolean(Fields.traderSpawnSphereNotificationRadius);
         final List<String> oldTraderSpawnNotificationCommands = config.getStringList(Fields.traderSpawnNotificationCommands);
         if (oldTraderSpawnNotificationRadius != 0 || !oldTraderSpawnNotificationCommands.isEmpty()) {
             config.set(Fields.traderSpawnNotificationRadius, null);
@@ -67,7 +68,8 @@ public final class Config extends DefaultedConfig {
                 oldTraderSpawnNotificationRadius != -1,
                 TraderSpawnNotificationOptions.Players.parse(String.valueOf(
                     oldTraderSpawnNotificationRadius == -1 ? 500 : oldTraderSpawnNotificationRadius
-                )),
+                ), sphereTraderNotificationRadius),
+                sphereTraderNotificationRadius,
                 List.of(),
                 oldTraderSpawnNotificationCommands
             );
@@ -215,6 +217,7 @@ public final class Config extends DefaultedConfig {
         public static final String refreshCommandTradersMinutes = "refreshCommandTradersMinutes";
         public static final String updateChecker = "updateChecker";
         public static final String traderSpawnNotificationRadius = "traderSpawnNotificationRadius";
+        public static final String traderSpawnSphereNotificationRadius = "traderSpawnSphereNotificationRadius";
         public static final String traderSpawnNotificationCommands = "traderSpawnNotificationCommands";
         public static final String traderSpawnNotifications = "traderSpawnNotifications";
     }

--- a/src/main/java/xyz/jpenilla/wanderingtrades/config/TraderSpawnNotificationOptions.java
+++ b/src/main/java/xyz/jpenilla/wanderingtrades/config/TraderSpawnNotificationOptions.java
@@ -68,7 +68,7 @@ public record TraderSpawnNotificationOptions(
             }
             try {
                 final int radius = Integer.parseInt(value);
-                return withInput(value, trader -> trader.getLocation().getNearbyPlayers(radius));
+                return withInput(value, trader -> trader.getLocation().getNearbyEntitiesByType(Player.class, radius, trader.getLocation().getWorld().getMaxHeight(), radius));
             } catch (final NumberFormatException ex) {
                 throw new IllegalArgumentException("Invalid players option, got '" + value + "', expected 'all', 'world', or an integer number for radius.");
             }

--- a/src/main/java/xyz/jpenilla/wanderingtrades/config/TraderSpawnNotificationOptions.java
+++ b/src/main/java/xyz/jpenilla/wanderingtrades/config/TraderSpawnNotificationOptions.java
@@ -72,7 +72,7 @@ public record TraderSpawnNotificationOptions(
             }
             try {
                 final int radius = Integer.parseInt(value);
-                return withInput(value, trader -> trader.getLocation().getNearbyEntitiesByType(Player.class, radius, sphereRadius ? radius : trader.getLocation().getWorld().getMaxHeight(), radius));
+                return withInput(value, trader -> trader.getLocation().getWorld().getNearbyEntities(trader.getLocation(), radius, sphereRadius ? radius : trader.getLocation().getWorld().getMaxHeight() - trader.getLocation().getWorld().getMinHeight(), radius, k -> k instanceof Player).stream().map(k -> (Player) k).toList());
             } catch (final NumberFormatException ex) {
                 throw new IllegalArgumentException("Invalid players option, got '" + value + "', expected 'all', 'world', or an integer number for radius.");
             }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -72,7 +72,7 @@ traderSpawnNotifications:
   #
   # Requires 'wanderingtrades.trader-spawn-notifications' permission, which defaults to true
   notifyPlayers: 500
-
+  sphereRadius: true
   # Commands to run when a trader spawns
   commands:
     - "effect give {trader-uuid} glowing 30"


### PR DESCRIPTION
Wandering traders can spawn outside the 48 block default radius on the Y level.
Currently, the plugin checks on a spherical radius centered on the wandering trader's position, however that can lead to issues.

This PR consists on adding a new configuration option "sphereRadius" which changes the mode on how the player check is done.

The function getNearbyPlayers calls getNearbyEntities with a single double as the radius. 